### PR TITLE
Infer identifier as relative path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,11 +95,17 @@ Write documents in the following directory structure:
     ontology/
         some-scenario/
             scenario.md
-        another-scenario/
-            scenario.md
-        yet-another-scenario/
-            scenario.md
+        some-group/
+            another-scenario/
+                scenario.md
+            yet-another-scenario/
+                scenario.md
     ...
+
+The identifier of a scenarios is given by the POSIX path of the scenario directory relative to
+the ontology directory.
+
+For example, ``some-scenario`` and ``some-group/another-scenario``.
 
 Header
 ~~~~~~
@@ -111,11 +117,10 @@ Here is an example:
 
     <rasaeco-meta>
     {
-        "identifier": "some_scenario",
         "title": "Some Scenario",
         "relations": [
-            { "target": "another_scenario", "nature": "is instance of" }
-            { "target": "yet_another_scenario", "nature": "refines" }
+            { "target": "some-group/another_scenario", "nature": "is instance of" }
+            { "target": "some-group/yet_another_scenario", "nature": "refines" }
         ],
         "volumetric": [
             {

--- a/rasaeco/meta.py
+++ b/rasaeco/meta.py
@@ -29,7 +29,6 @@ class Cubelet(TypedDict):
 class Meta(TypedDict):
     """Represent meta information extracted from a scenario markdown."""
 
-    identifier: str
     title: str
     relations: List[RelatesTo]
     volumetric: List[Cubelet]

--- a/rasaeco/render.py
+++ b/rasaeco/render.py
@@ -731,11 +731,6 @@ def once(scenarios_dir: pathlib.Path) -> List[str]:
 
         assert meta is not None
 
-        if meta["identifier"] in path_map:
-            errors.append(
-                f"In file {pth}: Identifier conflicts with the file {path_map[meta['identifier']]}"
-            )
-
         for i, cubelet in enumerate(meta["volumetric"]):
             ##
             # Verify aspect range
@@ -768,8 +763,10 @@ def once(scenarios_dir: pathlib.Path) -> List[str]:
                     f"In file {pth} and cubelet {i + 1}: Invalid level range: {range_error}"
                 )
 
-        meta_map[meta["identifier"]] = meta
-        path_map[meta["identifier"]] = pth
+        identifier = pth.parent.relative_to(scenarios_dir).as_posix()
+
+        meta_map[identifier] = meta
+        path_map[identifier] = pth
 
     scenario_id_set = set(meta_map.keys())
 

--- a/sample_scenarios/scaffolding/scenario.md
+++ b/sample_scenarios/scaffolding/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "scaffolding",
     "title": "Scaffolding",
     "relations": [
         { "target": "z_dummy_scenario", "nature": "is instance of" }

--- a/sample_scenarios/z_dummy_scenario/scenario.md
+++ b/sample_scenarios/z_dummy_scenario/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta id="f">
 {
-    "identifier": "z_dummy_scenario",
     "title": "Z Dummy Scenario",
     "relations": [],
     "volumetric": [

--- a/tests/failure_cases/invalid_aspect_range/scenario.md
+++ b/tests/failure_cases/invalid_aspect_range/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],

--- a/tests/failure_cases/invalid_level_range/scenario.md
+++ b/tests/failure_cases/invalid_level_range/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],

--- a/tests/failure_cases/invalid_modelref/scenario.md
+++ b/tests/failure_cases/invalid_modelref/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],

--- a/tests/failure_cases/invalid_phase_range/scenario.md
+++ b/tests/failure_cases/invalid_phase_range/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],

--- a/tests/failure_cases/invalid_ref/scenario.md
+++ b/tests/failure_cases/invalid_ref/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],

--- a/tests/failure_cases/invalid_relation_reference/scenario.md
+++ b/tests/failure_cases/invalid_relation_reference/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "scaffolding",
     "title": "Scaffolding",
     "relations": [
         { "target": "non-existing scenario", "nature": "is instance of" }

--- a/tests/failure_cases/missing_closing_tag_in_body/scenario.md
+++ b/tests/failure_cases/missing_closing_tag_in_body/scenario.md
@@ -1,6 +1,5 @@
 <rasaeco-meta>
 {
-    "identifier": "invalid",
     "title": "Invalid",
     "relations": [
     ],


### PR DESCRIPTION
Specifying the identifier in the meta tag is error-prone as we already
rely on the directory structure. This removes the `identifier` property
from the meta tag and enforces relative POSIX path as the identifier.