### PR TITLE
Fix failing unit tests

### DIFF
--- a/tests/failure_cases/invalid_level_range/expected.err
+++ b/tests/failure_cases/invalid_level_range/expected.err
@@ -1,1 +1,1 @@
-In file <path to scenario.md> and cubelet 1: Invalid level range: Unexpected end of a level range: 'totally invalid'; possible levels are: ['device', 'machine', 'zone', 'site', 'office', 'company', 'network']
+In file <path to scenario.md> and cubelet 1: Invalid level range: Unexpected end of a level range: 'totally invalid'; possible levels are: ['device/person', 'machine/crew', 'zone', 'site', 'office', 'company', 'network']


### PR DESCRIPTION
Some of the expected data in the unit tests had to be re-recorded. The
errors went unnoticed since our continuous integration on Travis stopped
working.