### PR TITLE
Improve error messages on `scenarios_dir`

### DIFF
--- a/rasaeco/pyrasaeco_render.py
+++ b/rasaeco/pyrasaeco_render.py
@@ -152,7 +152,9 @@ class ThreadedServer:
 
         class Handler(http.server.SimpleHTTPRequestHandler):
             def __init__(self, *args, **kwargs):  # type: ignore
-                super().__init__(*args, directory=str(scenarios_dir), **kwargs)  # type: ignore
+                super().__init__(
+                    *args, directory=str(scenarios_dir), **kwargs
+                )  # type: ignore
 
             def log_message(self, format, *args):  # type: ignore
                 pass
@@ -330,6 +332,24 @@ def run(argv: List[str], stdout: TextIO, stderr: TextIO) -> int:
         for error in errors:
             print(error, file=stderr)
             return 1
+
+    assert command is not None
+
+    if not command.scenarios_dir.exists():
+        print(
+            f"The directory you specified in --scenarios_dir does not exist "
+            f"on your system: {command.scenarios_dir}",
+            file=stderr,
+        )
+        return 1
+
+    if not command.scenarios_dir.is_dir():
+        print(
+            f"The path you specified in --scenarios_dir is expected to be a directory, "
+            f"but it is not: {command.scenarios_dir}",
+            file=stderr,
+        )
+        return 1
 
     if isinstance(command, Once):
         errors = rasaeco.render.once(scenarios_dir=command.scenarios_dir)

--- a/tests/pyrasaeco_render/test_graceful_failures.py
+++ b/tests/pyrasaeco_render/test_graceful_failures.py
@@ -8,6 +8,49 @@ import unittest
 import rasaeco.pyrasaeco_render
 
 
+class TestInvalidScenariosDir(unittest.TestCase):
+    def test_not_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scenarios_dir = os.path.join(tmp_dir, "does-not-exist")
+            argv = ["once", "--scenarios_dir", scenarios_dir]
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = rasaeco.pyrasaeco_render.run(
+                argv=argv, stdout=stdout, stderr=stderr
+            )
+
+            self.assertEqual(1, exit_code)
+            self.assertEqual(
+                f"The directory you specified in --scenarios_dir does not exist "
+                f"on your system: {scenarios_dir}\n",
+                stderr.getvalue(),
+            )
+
+    def test_not_a_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scenarios_dir = os.path.join(tmp_dir, "actually-a-file")
+            with open(scenarios_dir, "wt") as fid:
+                fid.write("oi")
+
+            argv = ["once", "--scenarios_dir", scenarios_dir]
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            exit_code = rasaeco.pyrasaeco_render.run(
+                argv=argv, stdout=stdout, stderr=stderr
+            )
+
+            self.assertEqual(1, exit_code)
+            self.assertEqual(
+                f"The path you specified in --scenarios_dir is expected "
+                f"to be a directory, but it is not: {scenarios_dir}\n",
+                stderr.getvalue(),
+            )
+
+
 class TestOnFailureCases(unittest.TestCase):
     def test_that_failures_are_handled_gracefully(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent


### PR DESCRIPTION
This patch makes the error messages a bit more informative when the
supplied `scenarios_dir` is invalid (*e.g.*, does not exist or not a
directory).