### PR TITLE
Instruct to use better `venv` directory name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,19 +65,19 @@ Create a virtual environment:
 
 .. code-block::
 
-    python -m venv venv
+    python -m venv venv-rasaeco
 
 Activate it (in Windows):
 
 .. code-block::
 
-    venv\Scripts\activate
+    venv-rasaeco\Scripts\activate
 
 or in Linux:
 
 .. code-block::
 
-    source venv/bin/activate
+    source venv-rasaeco/bin/activate
 
 Install the tool in the virtual environment:
 


### PR DESCRIPTION
The users were confused that the module name and the target for the
creation of the virtual environment are the same. In this patch, we
suggest the user to use a more discernable directory name to avoid the
potential confusion.